### PR TITLE
Add id_list argument to get_courses

### DIFF
--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -192,7 +192,7 @@ class Pluvo:
             'description': description, 'published_from': published_from,
             'published_to': published_to, 'student_id': student_id,
             'creator_id': creator_id, 'creation_date_from': creation_date_from,
-            'creation_date_to': creation_date_to, 'id_list':id_list
+            'creation_date_to': creation_date_to, 'id': id_list
         }
         return self._get_multiple('course/', params=params)
 

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -186,13 +186,13 @@ class Pluvo:
     def get_courses(self, offset=None, limit=None, title=None,
                     description=None, published_from=None, published_to=None,
                     student_id=None, creator_id=None, creation_date_from=None,
-                    creation_date_to=None):
+                    creation_date_to=None, id_list=None):
         params = {
             'offset': offset, 'limit': limit, 'title': title,
             'description': description, 'published_from': published_from,
             'published_to': published_to, 'student_id': student_id,
             'creator_id': creator_id, 'creation_date_from': creation_date_from,
-            'creation_date_to': creation_date_to
+            'creation_date_to': creation_date_to, 'id_list':id_list
         }
         return self._get_multiple('course/', params=params)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coverage==4.0.2
 flake8==2.6.2
+mock==2.0.0
 pytest==2.8.2
 pytest-cov==2.2.0
 pytest-flake8==0.2

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -453,7 +453,7 @@ def test_pluvo_get_courses(mocker):
     p = pluvo.Pluvo()
     mocker.patch.object(p, '_get_multiple')
 
-    retval = p.get_courses(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    retval = p.get_courses(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12)
 
     assert retval == p._get_multiple.return_value
     p._get_multiple.assert_called_once_with(
@@ -462,7 +462,8 @@ def test_pluvo_get_courses(mocker):
             'description': 4, 'published_from': 5,
             'published_to': 6, 'student_id': 7,
             'creator_id': 8, 'creation_date_from': 9,
-            'creation_date_to': 10
+            'creation_date_to': 10,
+            'id': 12
         })
 
 


### PR DESCRIPTION
This allows hydra to limit the amount of objects returned to what it actually needs.