### PR TITLE
add limit and offset to progress report

### DIFF
--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -265,11 +265,13 @@ class Pluvo:
             return self._request('POST', 'user/', user)
 
     def get_progress_report(self, student_ids=None, course_ids=None,
-                            order_by=None):
+                            order_by=None, offset=None, limit=None):
         params = {
             'student_id': student_ids,
             'course_id': course_ids,
-            'order_by': order_by
+            'order_by': order_by,
+            'offset': offset,
+            'limit': limit
         }
         return self._get_multiple('progress/reports/', params=params)
 

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -522,12 +522,14 @@ def test_pluvo_get_progress_report(mocker):
     p = pluvo.Pluvo(token='token')
     mocker.patch.object(p, '_get_multiple')
 
-    retval = p.get_progress_report([1, 2], [3, 4], ['-student_id'])
+    retval = p.get_progress_report([1, 2], [3, 4], ['-student_id'], 10, 0)
     assert retval == p._get_multiple.return_value
     p._get_multiple.assert_called_once_with('progress/reports/', params={
         'student_id': [1, 2],
         'course_id': [3, 4],
-        'order_by': ['-student_id']
+        'order_by': ['-student_id'],
+        'offset': 10,
+        'limit': 0,
     })
 
 


### PR DESCRIPTION
necessary if we want to fetch less than the entire list, to let the client implement pagination.