### PR TITLE
make PluvoGenerator more versatile

### DIFF
--- a/pluvo/__init__.py
+++ b/pluvo/__init__.py
@@ -1,1 +1,1 @@
-from .pluvo import Pluvo, PluvoException, PluvoAPIException, PluvoMisconfigured, PluvoGenerator, DEFAULT_API_URL, DEFAULT_PAGE_SIZE  # noqa
+from .pluvo import Pluvo, PluvoException, PluvoAPIException, PluvoMisconfigured, PluvoResultSet, DEFAULT_API_URL, DEFAULT_PAGE_SIZE  # noqa

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -1,5 +1,6 @@
 import itertools
 import requests
+import sys
 
 
 DEFAULT_API_URL = 'https://api.pluvo.co/rest/'
@@ -25,7 +26,7 @@ class PluvoMisconfigured(PluvoException):
     """Raised when the API is not correctly configured."""
 
 
-class PluvoResultSet:
+class PluvoResultSet(object):
     """Returned for list API calls
 
     This object can be indexed, sliced, and iterated over like a regular

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -94,6 +94,14 @@ class PluvoResultSet(object):
 
     def __len__(self):
         if self._count is None:
+            # TODO
+            # there is an optimization opportunity here: sometimes
+            # when we call len() we already have some good guess which page
+            # we're going to need. If we access resultset[40], for example, the
+            # code does a bounds check which leads us to request the 0th page
+            # (which we'll definitely don't need). I don't expect this to occur
+            # frequently though. slices require no bound checks, and how often
+            # would you need a specific item from the middle of the set?
             self._get_page(0)
         return self._count
 

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -87,6 +87,8 @@ class PluvoResultSet(object):
                     result.extend(self._get_page(stop_key)[:stop_offset])
                 return result
         else:
+            if key >= len(self):
+                raise IndexError("PluvoResultSet index out of range")
             key, offset = self._get_page_key_offset(canonicalize(key))
             return self._get_page(key)[offset]
 

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -1,6 +1,5 @@
 import itertools
 import requests
-import sys
 
 
 DEFAULT_API_URL = 'https://api.pluvo.co/rest/'

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -1,4 +1,4 @@
-import copy
+import itertools
 import requests
 
 
@@ -25,73 +25,80 @@ class PluvoMisconfigured(PluvoException):
     """Raised when the API is not correctly configured."""
 
 
-class PluvoGenerator:
+class PluvoResultSet:
     """Returned for list API calls
 
-    Immediately gets the first page of a list API call. The length is set
-    using the `count` result from the call, so is not nessecary to get
-    all items to know the total count.
+    This object can be indexed, sliced, and iterated over like a regular
+    sequence. Result pages will be fetched as needed from Pluvo.
 
     Page size can be set when instantiating the `Pluvo` object using
     `page_size`, otherwise the `DEFAULT_PAGE_SIZE` is used.
-
-    Items are yielded using a generator. When the items from the first page
-    request are all yielded, the next page is retrieved."""
+    """
 
     def __init__(self, pluvo, endpoint, params=None):
         self.pluvo = pluvo
         self.endpoint = endpoint
         self.params = params if params is not None else {}
-        self.initial_limit = self.params.get('limit')
-        self.initial_offset = self.params.get('offset')
-        self.length = 0
 
-        result = self._get_next_page()
+        self._count = None
+        self.pages = {}
 
-        self.items = result['data']
+    def _get_page(self, index):
+        if index not in self.pages:
+            params = dict(self.params, offset=index * self.pluvo.page_size,
+                          limit=self.pluvo.page_size)
+            resp = self.pluvo._request('GET', self.endpoint, params=params)
+            self.pages[index] = resp['data']
+            if self._count is None:
+                self._count = resp['count']
+        return self.pages[index]
 
-    def _get_next_page(self, initial=True):
-        if initial and (self.initial_limit is None
-                        or self.initial_limit > self.pluvo.page_size):
-            self.params['limit'] = self.pluvo.page_size
-        if initial and self.initial_offset is None:
-            self.params['offset'] = 0
+    def _get_page_key_offset(self, key):
+        """transform a key into a page key and offset in to the page"""
+        return key // self.pluvo.page_size, key % self.pluvo.page_size
 
-        if self.params['limit'] <= 0:
-            return {'data': []}
+    def __getitem__(self, key):
+        def canonicalize(key):
+            """transform negative keys to regular ones"""
+            if key < 0:
+                key = len(self) + key
+            return key
 
-        params = copy.copy(self.params)
-        result = self.pluvo._request('GET', self.endpoint, params=params)
-        if not self.length:
-            if self.initial_limit is None \
-                    or self.initial_limit > result['count']:
-                self.length = result['count']
-                if self.initial_offset is not None:
-                    self.length -= self.initial_offset
+        if isinstance(key, slice):
+            start = canonicalize(
+                key.start if key.start is not None else 0)
+            stop = canonicalize(
+                key.stop if key.stop is not None else len(self))
+
+            if start > stop:
+                return []
+
+            start_key, start_offset = self._get_page_key_offset(start)
+            stop_key, stop_offset = self._get_page_key_offset(stop)
+
+            if start_key == stop_key:
+                # slice is contained within a single page
+                return self._get_page(start_key)[start_offset:stop_offset]
             else:
-                self.length = self.initial_limit
-
-        next_page_size = min(
-            self.params['limit'],
-            (self.length - self.params['offset'] - self.params['limit']))
-        self.params['offset'] += self.params['limit']
-        self.params['limit'] = next_page_size
-        return result
+                result = self._get_page(start_key)[start_offset:]
+                for k in range(start_key + 1, stop_key):
+                    result.extend(self._get_page(k))
+                if stop_offset > 0:
+                    result.extend(self._get_page(stop_key)[:stop_offset])
+                return result
+        else:
+            key, offset = self._get_page_key_offset(canonicalize(key))
+            return self._get_page(key)[offset]
 
     def __len__(self):
-        return self.length
+        if self._count is None:
+            self._get_page(0)
+        return self._count
 
     def __iter__(self):
-        i = 0
-        while True:
-            for item in self.items:
-                yield item
-                i += 1
-                if i >= self.length:
-                    return
-            self.items = self._get_next_page(initial=False)['data']
-            if not self.items:
-                return
+        return itertools.chain(*(
+            iter(self._get_page(key))
+            for key in range(0, len(self) // self.pluvo.page_size)))
 
 
 class Pluvo:
@@ -186,7 +193,7 @@ class Pluvo:
         return data
 
     def _get_multiple(self, endpoint, params=None):
-        return PluvoGenerator(pluvo=self, endpoint=endpoint, params=params)
+        return PluvoResultSet(pluvo=self, endpoint=endpoint, params=params)
 
     def get_course(self, course_id):
         return self._request('GET', 'course/{}/'.format(course_id))

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -70,6 +70,7 @@ def test_pluvo_resultset_getitem(mocker):
         assert p[-1] == 7
         assert p[:1] == [0]
         assert p[-3:] == [5, 6, 7]
+        assert p[:-3] == [0, 1, 2, 3, 4]
         assert p[8:1] == []
         assert p[0:1] == [0]
         assert p[3:7] == [3, 4, 5, 6]
@@ -91,6 +92,7 @@ def test_pluvo_resultset_len(mocker):
 
     assert len(p) == 4
     assert len(p) == 4
+    # assert that even though len is called twice, we do not make 2 requests
     assert pluvo_mock._request.call_count == 1
 
 

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -73,6 +73,8 @@ def test_pluvo_resultset_getitem(mocker):
         assert p[8:1] == []
         assert p[0:1] == [0]
         assert p[3:7] == [3, 4, 5, 6]
+        with pytest.raises(IndexError):
+            p[8]
 
 
 def test_pluvo_resultset_len(mocker):

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -1,8 +1,8 @@
-from mock import call
+from mock import call, patch
 import pytest
 
 import pluvo
-from pluvo import PluvoGenerator, DEFAULT_API_URL, DEFAULT_PAGE_SIZE
+from pluvo import PluvoResultSet, DEFAULT_API_URL, DEFAULT_PAGE_SIZE
 
 
 class Multiple:
@@ -17,112 +17,97 @@ class Multiple:
         return result
 
 
-def test_pluvo_generator_one_page(mocker):
+def test_pluvo_resultset_get_page(mocker):
     pages = [
-        {'count': 2, 'data': [1, 2]}
+        {'count': 4, 'data': [0, 1]},
+        {'count': 4, 'data': [2, 3]}
     ]
+    i = iter(pages)
 
-    _request_mock = mocker.MagicMock(side_effect=Multiple(pages).results)
-    pluvo_mock = mocker.MagicMock(page_size=2, _request=_request_mock)
+    request_mock = mocker.MagicMock(
+        side_effect=lambda *args, **kwargs: next(i))
+    pluvo_mock = mocker.MagicMock(page_size=2, _request=request_mock)
 
-    retval = PluvoGenerator(pluvo_mock, 'endpoint')
+    p = PluvoResultSet(pluvo_mock, 'endpoint')
+    page0 = p._get_page(0)
+    # make sure that fetching twice doesn't generate a new request
+    page0_again = p._get_page(0)
+    page1 = p._get_page(1)
 
-    assert len(retval) == 2
-    assert list(retval) == [1, 2]
-    _request_mock.assert_has_calls([
-        call('GET', 'endpoint', params={'limit': 2, 'offset': 0})])
+    assert page0 == page0_again
+    assert page0 == pages[0]['data']
+    assert page1 == pages[1]['data']
 
-
-def test_pluvo_generator_two_pages(mocker):
-    pages = [
-        {'count': 4, 'data': [1, 2]},
-        {'count': 4, 'data': [3, 4]}
-    ]
-
-    _request_mock = mocker.MagicMock(side_effect=Multiple(pages).results)
-    pluvo_mock = mocker.MagicMock(page_size=2, _request=_request_mock)
-
-    retval = PluvoGenerator(pluvo_mock, 'endpoint')
-
-    assert len(retval) == 4
-    assert list(retval) == [1, 2, 3, 4]
-    _request_mock.assert_has_calls([
+    pluvo_mock._request.assert_has_calls([
         call('GET', 'endpoint', params={'limit': 2, 'offset': 0}),
-        call('GET', 'endpoint', params={'limit': 2, 'offset': 2})
+        call('GET', 'endpoint', params={'limit': 2, 'offset': 2}),
     ])
 
 
-def test_pluvo_generator_limit(mocker):
+def test_pluvo_resultset_get_page_key_offset(mocker):
+    pluvo_mock = mocker.MagicMock(page_size=2)
+    p = PluvoResultSet(pluvo_mock, 'endpoint')
+
+    assert p._get_page_key_offset(0) == (0, 0)
+    assert p._get_page_key_offset(1) == (0, 1)
+    assert p._get_page_key_offset(7) == (3, 1)
+
+
+def test_pluvo_resultset_getitem(mocker):
     pages = [
-        {'count': 4, 'data': [1, 2]},
-        {'count': 4, 'data': [3, 4]}
+        [0, 1],
+        [2, 3],
+        [4, 5],
+        [6, 7],
     ]
 
-    _request_mock = mocker.MagicMock(side_effect=Multiple(pages).results)
-    pluvo_mock = mocker.MagicMock(page_size=2, _request=_request_mock)
+    get_page_mock = mocker.MagicMock(side_effect=lambda x: pages[x])
+    pluvo_mock = mocker.MagicMock(page_size=2)
+    p = PluvoResultSet(pluvo_mock, 'endpoint')
+    p._count = 8
+    with patch.object(p, '_get_page', get_page_mock):
+        assert p[:] == [0, 1, 2, 3, 4, 5, 6, 7]
+        assert p[-1] == 7
+        assert p[:1] == [0]
+        assert p[-3:] == [5, 6, 7]
+        assert p[8:1] == []
+        assert p[0:1] == [0]
+        assert p[3:7] == [3, 4, 5, 6]
 
-    retval = PluvoGenerator(pluvo_mock, 'endpoint', params={'limit': 3})
 
-    assert len(retval) == 3
-    assert list(retval) == [1, 2, 3]
-    _request_mock.assert_has_calls([
-        call('GET', 'endpoint', params={'limit': 2, 'offset': 0}),
-        call('GET', 'endpoint', params={'limit': 1, 'offset': 2})
-    ])
-
-
-def test_pluvo_generator_offset(mocker):
+def test_pluvo_resultset_len(mocker):
     pages = [
-        {'count': 4, 'data': [3, 4]}
+        {'count': 4, 'data': [0, 1]},
+        {'count': 4, 'data': [2, 3]}
+    ]
+    i = iter(pages)
+
+    request_mocker = mocker.MagicMock(
+        side_effect=lambda *args, **kwargs: next(i))
+    pluvo_mock = mocker.MagicMock(page_size=2, _request=request_mocker)
+    p = PluvoResultSet(pluvo_mock, 'endpoint')
+
+    assert len(p) == 4
+    assert len(p) == 4
+    assert pluvo_mock._request.call_count == 1
+
+
+def test_pluvo_resultset_iter(mocker):
+    pages = [
+        [1, 2],
+        [3, 4],
+        [5, 6],
     ]
 
-    _request_mock = mocker.MagicMock(side_effect=Multiple(pages).results)
-    pluvo_mock = mocker.MagicMock(page_size=2, _request=_request_mock)
-
-    retval = PluvoGenerator(pluvo_mock, 'endpoint', params={'offset': 2})
-
-    assert len(retval) == 2
-    assert list(retval) == [3, 4]
-    _request_mock.assert_has_calls([
-        call('GET', 'endpoint', params={'limit': 2, 'offset': 2})
-    ])
-
-
-def test_pluvo_generator_limit_and_offset(mocker):
-    pages = [
-        {'count': 1, 'data': [3]}
-    ]
-
-    _request_mock = mocker.MagicMock(side_effect=Multiple(pages).results)
-    pluvo_mock = mocker.MagicMock(page_size=2, _request=_request_mock)
-
-    retval = PluvoGenerator(pluvo_mock, 'endpoint',
-                            params={'limit': 1, 'offset': 2})
-
-    assert len(retval) == 1
-    assert list(retval) == [3]
-    _request_mock.assert_has_calls([
-        call('GET', 'endpoint', params={'limit': 1, 'offset': 2})
-    ])
-
-
-def test_pluvo_generator_retrieving_less_items(mocker):
-    pages = [
-        {'count': 3, 'data': [1, 2]},
-        {'count': 3, 'data': []}
-    ]
-
-    _request_mock = mocker.MagicMock(side_effect=Multiple(pages).results)
-    pluvo_mock = mocker.MagicMock(page_size=2, _request=_request_mock)
-
-    retval = PluvoGenerator(pluvo_mock, 'endpoint')
-
-    assert len(retval) == 3
-    assert list(retval) == [1, 2]
-    _request_mock.assert_has_calls([
-        call('GET', 'endpoint', params={'limit': 2, 'offset': 0}),
-        call('GET', 'endpoint', params={'limit': 1, 'offset': 2})
-    ])
+    get_page_mock = mocker.MagicMock(side_effect=lambda x: pages[x])
+    pluvo_mock = mocker.MagicMock(page_size=2)
+    p = PluvoResultSet(pluvo_mock, 'endpoint')
+    p._count = 6
+    with patch.object(p, '_get_page', get_page_mock):
+        assert list(iter(p)) == [1, 2, 3, 4, 5, 6]
+        get_page_mock.assert_has_calls([
+            call(0), call(1), call(2)
+        ])
 
 
 def test_pluvo_init_client_credentials():
@@ -298,7 +283,7 @@ def test_pluvo_request_error_no_error_data(mocker):
 
 def test_pluvo_get_multiple(mocker):
     p = pluvo.Pluvo(token='token')
-    pluvo_generator_mock = mocker.patch('pluvo.pluvo.PluvoGenerator')
+    pluvo_generator_mock = mocker.patch('pluvo.pluvo.PluvoResultSet')
 
     p._get_multiple('endpoint', params='params')
 


### PR DESCRIPTION
Instead of just being an iterable object, PluvoGenerator is now much
more like a full-featured sequence. It supports slicing and indexing
over the result set, fetching pages from pluvo as needed. I've renamed
the class PluvoResultSet.

The motivation for this feature is to allow Pluvo result sets to be easily
and efficiently used in e.g. the django Paginator class.

Note that offset and limit parameters are no longer supported (they are
ignored completely). The same effect can be achieved with very little
efficiency loss by slicing the result set instead, but this does 
constitute a backwards incompatible change.