### PR TITLE
support POST requests for resultsets

### DIFF
--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -206,8 +206,9 @@ class Pluvo:
                 raise PluvoException(msg)
         return data
 
-    def _get_multiple(self, endpoint, params=None):
-        return PluvoResultSet(pluvo=self, endpoint=endpoint, params=params)
+    def _get_multiple(self, endpoint, params=None, method='GET'):
+        return PluvoResultSet(
+            pluvo=self, endpoint=endpoint, params=params, method=method)
 
     def get_course(self, course_id):
         return self._request('GET', 'course/{}/'.format(course_id))

--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -35,8 +35,9 @@ class PluvoResultSet(object):
     `page_size`, otherwise the `DEFAULT_PAGE_SIZE` is used.
     """
 
-    def __init__(self, pluvo, endpoint, params=None):
+    def __init__(self, pluvo, endpoint, params=None, method='GET'):
         self.pluvo = pluvo
+        self.method = method
         self.endpoint = endpoint
         self.params = params if params is not None else {}
 
@@ -47,7 +48,10 @@ class PluvoResultSet(object):
         if index not in self.pages:
             params = dict(self.params, offset=index * self.pluvo.page_size,
                           limit=self.pluvo.page_size)
-            resp = self.pluvo._request('GET', self.endpoint, params=params)
+            if self.method == 'POST':
+                resp = self.pluvo._request('POST', self.endpoint, data=params)
+            else:
+                resp = self.pluvo._request('GET', self.endpoint, params=params)
             self.pages[index] = resp['data']
             if self._count is None:
                 self._count = resp['count']
@@ -290,7 +294,8 @@ class Pluvo:
             'offset': offset,
             'limit': limit
         }
-        return self._get_multiple('progress/reports/', params=params)
+        return self._get_multiple(
+            'progress/reports/', params=params, method='POST')
 
     def get_version(self):
         """Get the Pluvo API version."""

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -309,10 +309,10 @@ def test_pluvo_get_multiple(mocker):
     p = pluvo.Pluvo(token='token')
     pluvo_generator_mock = mocker.patch('pluvo.pluvo.PluvoResultSet')
 
-    p._get_multiple('endpoint', params='params')
+    p._get_multiple('endpoint', params='params', method='POST')
 
     pluvo_generator_mock.assert_called_once_with(
-        pluvo=p, endpoint='endpoint', params='params')
+        pluvo=p, endpoint='endpoint', params='params', method='POST')
 
 
 def test_pluvo_put(mocker):

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -44,6 +44,26 @@ def test_pluvo_resultset_get_page(mocker):
     ])
 
 
+def test_pluvo_resultset_post_page(mocker):
+    pages = [
+        {'count': 4, 'data': [0, 1]},
+        {'count': 4, 'data': [2, 3]}
+    ]
+    i = iter(pages)
+
+    request_mock = mocker.MagicMock(
+        side_effect=lambda *args, **kwargs: next(i))
+    pluvo_mock = mocker.MagicMock(page_size=2, _request=request_mock)
+
+    p = PluvoResultSet(pluvo_mock, 'endpoint', method='POST')
+    page0 = p._get_page(0)
+    assert page0 == [0, 1]
+
+    pluvo_mock._request_assert_has_calls([
+        call('POST', 'endpoint', data={'limit': 2, 'offset': 0})
+    ])
+
+
 def test_pluvo_resultset_get_page_key_offset(mocker):
     pluvo_mock = mocker.MagicMock(page_size=2)
     p = PluvoResultSet(pluvo_mock, 'endpoint')
@@ -519,7 +539,7 @@ def test_pluvo_get_progress_report(mocker):
         'order_by': ['-student_id'],
         'offset': 10,
         'limit': 0,
-    })
+    }, method='POST')
 
 
 def test_pluvo_archive_student_course_version(mocker):


### PR DESCRIPTION
we want the progress report to happen via post request, so we have to
update result sets to support them.