### PR TITLE
Add filename arg to get_course_report

### DIFF
--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -303,9 +303,10 @@ class Pluvo:
         return self._get_multiple(
             'progress/reports/', params=params, method='GET')
 
-    def get_course_report(self, course_id, student_id):
+    def get_course_report(self, course_id, student_id, filename=None):
+        params = {'filename': filename} if filename else {}
         url = 'report/course/{}/user/{}/'.format(course_id, student_id)
-        return self._request('GET', url)
+        return self._request('GET', url, params=params)
 
     def get_version(self):
         """Get the Pluvo API version."""

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -580,7 +580,18 @@ def test_pluvo_get_course_report(mocker):
     retval = p.get_course_report(1, 2)
     assert retval == p._request.return_value
     p._request.assert_called_once_with(
-        'GET', 'report/course/1/user/2/')
+        'GET', 'report/course/1/user/2/', params={})
+
+
+def test_pluvo_get_course_report_filename(mocker):
+    p = pluvo.Pluvo(token='token')
+    mocker.patch.object(p, '_request')
+
+    filename = 'test.pdf'
+    retval = p.get_course_report(1, 2, filename)
+    assert retval == p._request.return_value
+    p._request.assert_called_once_with(
+        'GET', 'report/course/1/user/2/', params={'filename': filename})
 
 
 def test_pluvo_get_version(mocker):


### PR DESCRIPTION
When passing a filename the url that is returned contains `ResponseContentDisposition: attachment; filename=test.pdf` This will trigger browsers to download the file instead of showing a preview.