### PR TITLE
Properly filter student and courses

### DIFF
--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -321,8 +321,8 @@ class Pluvo:
             completion_date_to = completion_date_to.isoformat()
 
         params = {
-            'student_id': student_ids,
-            'course_id': course_ids,
+            'student_ids': student_ids,
+            'course_ids': course_ids,
             'order_by': order_by,
             'offset': offset,
             'limit': limit,

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -588,8 +588,8 @@ def test_pluvo_get_progress_report(mocker):
         [1, 2], [3, 4], ['-student_id'], 10, 0, dt1, dt2, True)
     assert retval == p._get_multiple.return_value
     p._get_multiple.assert_called_once_with('progress/reports/', params={
-        'student_id': [1, 2],
-        'course_id': [3, 4],
+        'student_ids': [1, 2],
+        'course_ids': [3, 4],
         'order_by': ['-student_id'],
         'offset': 10,
         'limit': 0,


### PR DESCRIPTION
Doing a GET request expects singular keys, a POST request expects
a dictionary with plural keys containing lists. This call was
changed from a GET to a POST request recently so avoid url-length
problems and therefore filtering by course id or by student id
has stopped working.