### PR TITLE
Add set_organisation_parent to the API client

### DIFF
--- a/pluvo/pluvo.py
+++ b/pluvo/pluvo.py
@@ -292,6 +292,11 @@ class Pluvo:
         else:
             return self._request('DELETE', 'organisation/{}/'.format(org_id))
 
+    def set_organisation_parent(self, organisation_id, parent_organisation_id):
+        return self._request(
+            'PUT', 'organisation/{}/parent/'.format(organisation_id),
+            {'parent_organisation_id': parent_organisation_id})
+
     def get_s3_upload_token(self, filename, media_type):
         return self._request(
             'GET',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='pluvo',
     packages=['pluvo'],
     package_data={},
-    version='0.3.0',
+    version='0.4.0',
     description='Python library to access the Pluvo REST API.',
     author='Wend BV',
     author_email='info@wend.nl',

--- a/tests/test_pluvo.py
+++ b/tests/test_pluvo.py
@@ -498,6 +498,17 @@ def test_pluvo_set_organisation_post(mocker):
     p._request.assert_called_once_with('POST', 'organisation/', {'test': 1})
 
 
+def test_pluvo_set_organisation_parent(mocker):
+    p = pluvo.Pluvo(token='token')
+    mocker.patch.object(p, '_request')
+
+    retval = p.set_organisation_parent(1, 2)
+
+    assert retval == p._request.return_value
+    p._request.assert_called_once_with(
+        'PUT', 'organisation/1/parent/', {'parent_organisation_id': 2})
+
+
 def test_pluvo_get_s3_upload_token(mocker):
     p = pluvo.Pluvo(token='token')
     mocker.patch.object(p, '_request')
@@ -748,3 +759,5 @@ async def test_shampoo_client_close(mocker):
     # Calling close again should be a no-op
     await client.close()
     mock_ws.close.assert_called_once()
+
+


### PR DESCRIPTION
Adds a `set_organisation_parent` method to the `Pluvo` client, wrapping `PUT /organisation/{id}/parent/` to set or clear an organisation's parent organisation. Includes a test and a package version bump.

Mocks/spec: https://github.com/wendbv/pluvo-specs/pull/238